### PR TITLE
Fix complexity rule name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   The eslint rule is named "complexity" and not "cyclomatic-complexity"
+
 ## [1.2.0] - 2023-03-22
 
 ### Changed

--- a/dist/index.js
+++ b/dist/index.js
@@ -14245,7 +14245,7 @@ const allowedCsSuppressions = [
 ];
 const allowedTsSuppressions = [
     "@typescript-eslint/naming-convention",
-    "cyclomatic-complexity",
+    "complexity",
     "no-console",
     "no-floating-promises",
     "no-param-reassign",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ const allowedCsSuppressions = [
 ];
 const allowedTsSuppressions = [
   "@typescript-eslint/naming-convention",
-  "cyclomatic-complexity",
+  "complexity",
   "no-console",
   "no-floating-promises",
   "no-param-reassign",


### PR DESCRIPTION
The eslint rule is named "complexity" and not "cyclomatic-complexity"
https://eslint.org/docs/latest/rules/complexity 
